### PR TITLE
Add `databases/` prefix for SQLite databases file path

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -81,7 +81,10 @@ class Application extends Controller with LazyLogging {
 
   private def prepareDatabase(dbName: String = "ui_demo.db", backend: String = "sqlite") =
   {
-    new Database(dbName, new JDBCBackend(backend, dbName))
+    backend match {
+      case "sqlite" => new Database(dbName, new JDBCBackend(backend, "databases/" + dbName))
+      case _        => new Database(dbName, new JDBCBackend(backend, dbName))
+    }
   }
 
   private def handleStatements(input: String): (List[Statement], List[WebResult]) = {


### PR DESCRIPTION
Due to the change introduced in mimir to fix the issue #99, webapp
should specify which directory it wants to store SQLite databases
files.